### PR TITLE
🔒 Stop tracking environment.ts, add example template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ testem.log
 Thumbs.db
 # Testing
 src/environments/environment.local.ts
-.vscode
+.vscodesrc/environments/environment.ts

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Generate environment.ts from environment variables or copy from example
+ENV_FILE="src/environments/environment.ts"
+EXAMPLE_FILE="src/environments/environment.example.ts"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Creating $ENV_FILE from example..."
+  cp "$EXAMPLE_FILE" "$ENV_FILE"
+  echo "⚠️  Edit $ENV_FILE with your local values or set CI/CD env vars."
+fi

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -1,0 +1,23 @@
+// Environment configuration
+// CI/CD replaces '---' placeholders via sed before production build
+// For local dev: copy to environment.local.ts with real values (gitignored)
+export const environment = {
+  production: false,
+  soundcloudClientId: '---',
+  soundcloudClientSecret: '---',
+  apiAuthToken: '---',
+  apiId: '---',
+  baseCallbackUrl: 'http://localhost:4200',
+  apiBaseUrl: 'https://api.soundcloud.com',
+  authBaseUrl: 'https://secure.soundcloud.com',
+  get xomcloudApiUrl(): string {
+    return this.apiId === '---' 
+      ? '' 
+      : `https://${this.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
+  },
+  get downloadApiUrl(): string {
+    return this.apiId === '---'
+      ? ''
+      : `https://${this.apiId}.execute-api.us-east-1.amazonaws.com/dev/download`;
+  }
+};


### PR DESCRIPTION
Removes `environment.ts` from git tracking and adds it to `.gitignore` to prevent accidental credential commits.

### Changes:
- `environment.ts` → untracked (gitignored)
- `environment.example.ts` → committed template with placeholder values
- `scripts/setup-env.sh` → helper to bootstrap local config

Devs copy the example file; CI/CD generates the real one from env vars.

Closes #4