### PR TITLE
feat(callback): forward XomFit OAuth state back to xomfit:// deep link

### DIFF
--- a/src/app/components/callback/callback.component.ts
+++ b/src/app/components/callback/callback.component.ts
@@ -10,9 +10,37 @@ import { AuthService } from '../../services/auth.service';
   styles: []
 })
 export class CallbackComponent implements OnInit {
+  // OAuth state values minted by XomFit (xomfit-ios) start with this prefix so
+  // this shared SoundCloud callback can route them back to the iOS deep link
+  // instead of completing the web auth flow. SoundCloud only allows one redirect
+  // URI per app, so XomFit reuses this Xomcloud endpoint.
+  private static readonly XOMFIT_STATE_PREFIX = 'xomfit-';
+  private static readonly XOMFIT_CALLBACK_URL = 'xomfit://soundcloud-callback';
+
   constructor(private authService: AuthService) {}
 
   ngOnInit(): void {
+    if (this.tryForwardToXomFit()) {
+      return;
+    }
     this.authService.handleCallback();
+  }
+
+  /**
+   * If this callback was kicked off by XomFit, the OAuth `state` carries our
+   * prefix and we forward the entire query string (including `code` + `state`)
+   * to the iOS deep link. ASWebAuthenticationSession on iOS terminates as soon
+   * as the `xomfit://` redirect fires, so the iOS app receives the params and
+   * the user never sees the rest of this page.
+   */
+  private tryForwardToXomFit(): boolean {
+    const params = new URLSearchParams(window.location.search);
+    const state = params.get('state') ?? '';
+    if (!state.startsWith(CallbackComponent.XOMFIT_STATE_PREFIX)) {
+      return false;
+    }
+    const target = `${CallbackComponent.XOMFIT_CALLBACK_URL}?${window.location.search.replace(/^\?/, '')}`;
+    window.location.replace(target);
+    return true;
   }
 }


### PR DESCRIPTION
## Summary

SoundCloud only allows one redirect URI per Developer App. XomFit (xomfit-ios) reuses this Xomcloud app's registered URI (`https://xomcloud.xomware.com/callback`) and prefixes its OAuth \`state\` with \`xomfit-\` so this component can route the callback back to the iOS deep link instead of completing the web auth flow.

## How it works

1. iOS app generates \`state = "xomfit-<random>"\` and kicks off auth at SoundCloud.
2. SoundCloud redirects to \`https://xomcloud.xomware.com/callback?code=...&state=xomfit-...\`.
3. This component sees the \`xomfit-\` prefix, replaces \`window.location\` with \`xomfit://soundcloud-callback?<same query>\`.
4. iOS \`ASWebAuthenticationSession\` (configured with \`callbackURLScheme = "xomfit"\`) intercepts and completes the PKCE token exchange in-app.
5. Xomcloud's own web auth (no \`xomfit-\` prefix) falls through to the existing \`AuthService.handleCallback()\` path — zero impact.

## Test plan
- [ ] Xomcloud's own SoundCloud sign-in still works end-to-end (loader shows, redirect to home, token persisted)
- [ ] XomFit-initiated sign-in (manual: append \`?state=xomfit-test\` to a fake callback URL with arbitrary code) redirects to \`xomfit://soundcloud-callback?...\` (visible in DevTools network or via "Open in" prompt on a device)