### PR TITLE
fix: route SoundCloud token exchange through xomcloud-backend proxy (closes #22)

### DIFF
--- a/src/app/components/callback/callback.component.ts
+++ b/src/app/components/callback/callback.component.ts
@@ -10,9 +10,37 @@ import { AuthService } from '../../services/auth.service';
   styles: []
 })
 export class CallbackComponent implements OnInit {
+  // OAuth state values minted by XomFit (xomfit-ios) start with this prefix so
+  // this shared SoundCloud callback can route them back to the iOS deep link
+  // instead of completing the web auth flow. SoundCloud only allows one redirect
+  // URI per app, so XomFit reuses this Xomcloud endpoint.
+  private static readonly XOMFIT_STATE_PREFIX = 'xomfit-';
+  private static readonly XOMFIT_CALLBACK_URL = 'xomfit://soundcloud-callback';
+
   constructor(private authService: AuthService) {}
 
   ngOnInit(): void {
+    if (this.tryForwardToXomFit()) {
+      return;
+    }
     this.authService.handleCallback();
+  }
+
+  /**
+   * If this callback was kicked off by XomFit, the OAuth `state` carries our
+   * prefix and we forward the entire query string (including `code` + `state`)
+   * to the iOS deep link. ASWebAuthenticationSession on iOS terminates as soon
+   * as the `xomfit://` redirect fires, so the iOS app receives the params and
+   * the user never sees the rest of this page.
+   */
+  private tryForwardToXomFit(): boolean {
+    const params = new URLSearchParams(window.location.search);
+    const state = params.get('state') ?? '';
+    if (!state.startsWith(CallbackComponent.XOMFIT_STATE_PREFIX)) {
+      return false;
+    }
+    const target = `${CallbackComponent.XOMFIT_CALLBACK_URL}?${window.location.search.replace(/^\?/, '')}`;
+    window.location.replace(target);
+    return true;
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,9 +1,9 @@
 // auth.service.ts - SoundCloud OAuth 2.1 with PKCE
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { BehaviorSubject, Observable, throwError } from 'rxjs';
-import { catchError, tap, switchMap } from 'rxjs/operators';
+import { catchError, tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { AuthToken, PKCEChallenge } from '../models';
 import { ToastService } from './toast.service';
@@ -130,34 +130,37 @@ export class AuthService {
       return;
     }
 
-    // NOTE: Token exchange should go through backend to keep client_secret secure.
-    // For now, send to SoundCloud directly with PKCE only (no client_secret).
-    // TODO: Move to backend endpoint at environment.tokenExchangeUrl
-    const tokenUrl = `${this.authBaseUrl}/oauth/token`;
-    const body = new URLSearchParams();
-    body.set('grant_type', 'authorization_code');
-    body.set('client_id', this.clientId);
-    body.set('redirect_uri', this.redirectUri);
-    body.set('code_verifier', codeVerifier);
-    body.set('code', code);
+    const tokenUrl = environment.tokenExchangeUrl;
+    const body = {
+      code,
+      code_verifier: codeVerifier,
+      redirect_uri: this.redirectUri,
+    };
 
     const headers = new HttpHeaders({
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'Accept': 'application/json; charset=utf-8',
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
     });
 
-    this.http.post<AuthToken>(tokenUrl, body.toString(), { headers }).subscribe({
+    this.http.post<AuthToken>(tokenUrl, body, { headers }).subscribe({
       next: (response) => {
         this.storeTokens(response);
         this.cleanupPKCE();
         this.router.navigate(['/my-profile']);
       },
-      error: () => {
-        this.toastService.showNegativeToast('Login failed. Please try again.');
+      error: (error: HttpErrorResponse) => {
+        this.toastService.showNegativeToast(this.getAuthErrorMessage(error));
         this.cleanupPKCE();
         this.router.navigate(['/home']);
       },
     });
+  }
+
+  private getAuthErrorMessage(error: HttpErrorResponse): string {
+    if (error.status === 401) {
+      return 'SoundCloud refused the sign-in. Please try again.';
+    }
+    return 'Login failed. Please try again.';
   }
 
   // ==================== Token Management ====================
@@ -199,20 +202,15 @@ export class AuthService {
       return throwError(() => new Error('No refresh token available'));
     }
 
-    // NOTE: Token refresh should also go through backend.
-    // TODO: Move to backend endpoint at environment.tokenExchangeUrl
-    const tokenUrl = `${this.authBaseUrl}/oauth/token`;
-    const body = new URLSearchParams();
-    body.set('grant_type', 'refresh_token');
-    body.set('client_id', this.clientId);
-    body.set('refresh_token', refreshToken);
+    const tokenUrl = environment.tokenRefreshUrl;
+    const body = { refresh_token: refreshToken };
 
     const headers = new HttpHeaders({
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'Accept': 'application/json; charset=utf-8',
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
     });
 
-    return this.http.post<AuthToken>(tokenUrl, body.toString(), { headers }).pipe(
+    return this.http.post<AuthToken>(tokenUrl, body, { headers }).pipe(
       tap((response) => {
         this.storeTokens(response);
       }),

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -27,5 +27,10 @@ export const environment = {
     return this.apiId === '---'
       ? ''
       : `https://${this.apiId}.execute-api.us-east-1.amazonaws.com/dev/auth/token`;
+  },
+  get tokenRefreshUrl(): string {
+    return this.apiId === '---'
+      ? ''
+      : `https://${this.apiId}.execute-api.us-east-1.amazonaws.com/dev/auth/refresh`;
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -27,5 +27,10 @@ export const environment = {
     return this.apiId === '---'
       ? ''
       : `https://${this.apiId}.execute-api.us-east-1.amazonaws.com/dev/auth/token`;
+  },
+  get tokenRefreshUrl(): string {
+    return this.apiId === '---'
+      ? ''
+      : `https://${this.apiId}.execute-api.us-east-1.amazonaws.com/dev/auth/refresh`;
   }
 };


### PR DESCRIPTION
## Summary
SoundCloud now requires \`client_secret\` at \`/oauth/token\` even with PKCE — Xomcloud's direct token exchange has been failing with 401. Moves the exchange + refresh through the new \`xomcloud-backend\` auth proxy (\`POST /auth/token\` + \`POST /auth/refresh\`) which holds the secret server-side via SSM.

- \`auth.service.ts\` — both \`exchangeCodeForToken\` and \`refreshAccessToken\` POST JSON to \`environment.tokenExchangeUrl\` / \`tokenRefreshUrl\` instead of \`secure.soundcloud.com/oauth/token\`. Drops \`client_id\` + \`grant_type\` from the body (backend supplies). Refresh path keeps silent error + logout behavior.
- New \`getAuthErrorMessage(HttpErrorResponse)\` — surfaces "SoundCloud refused the sign-in" on 401 distinct from generic "Login failed".
- \`environment.ts\` / \`.example.ts\` — added \`tokenRefreshUrl\` getter, same dev-placeholder behavior.

## Dependency
**Must merge after** xomcloud-backend PR (auth_token lambda) ships AND xomcloud-infrastructure PR is applied. Otherwise the proxy URL 404s.

## Test plan
- [ ] After deps land: sign in to Xomcloud → completes successfully, token persisted
- [ ] Refresh flow on app load uses the new endpoint
- [ ] Bridge for XomFit still works (xomfit-prefixed state returns early in CallbackComponent, never hits handleCallback)