### PR TITLE
Replace the last emoji (search empty state)

### DIFF
--- a/src/app/pages/search/search.component.html
+++ b/src/app/pages/search/search.component.html
@@ -51,7 +51,7 @@
 
   <!-- No Results -->
   <div class="empty-state" *ngIf="hasSearched && tracks.length === 0 && !loading && !error">
-    <span class="empty-icon">🔍</span>
+    <span class="empty-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg></span>
     <h2>No tracks found</h2>
     <p>Try a different search term</p>
   </div>


### PR DESCRIPTION
One 🔍 missed in the earlier sweep — it sits behind a "no results" condition, so it never appeared in a baseline screenshot. Found by grep, not by looking.

Replaced with the same inline SVG magnifier used on the home page feature card. All 12 visual baselines unchanged.

This repo is now emoji-free apart from `☰` and `✕`, which are text glyphs.